### PR TITLE
Remove async in the request for disconnection

### DIFF
--- a/custom_components/rd200_ble/rd200_ble/parser.py
+++ b/custom_components/rd200_ble/rd200_ble/parser.py
@@ -148,6 +148,6 @@ class RD200BluetoothDeviceData:
         client = await establish_connection(BleakClient, ble_device, ble_device.address)
         device = await self._get_radon(client, device)
         device = await self._get_radon_peak(client, device)
-        await client.disconnect()
+        client.disconnect()
 
         return device


### PR DESCRIPTION
Resolves #3 

With this single change I've been able to have 100% availability on all 4 entities for more than two hours (previous record was 10min).

Running on raspberry pi 4 with Home Assistant Operating System.

My RD200 is from Spain so FR:RE.

I strongly suggest to test it on other hardware, especially if there was no issues before.

![image](https://user-images.githubusercontent.com/126833/210012753-df1ca823-4cf7-40bb-9848-98da6bde5d9a.png)