### PR TITLE
US RD200 with FR:HA

### DIFF
--- a/custom_components/rd200_ble/config_flow.py
+++ b/custom_components/rd200_ble/config_flow.py
@@ -154,6 +154,8 @@ class RD200ConfigFlow(ConfigFlow, domain=DOMAIN):
                 or discovery_info.advertisement.local_name.startswith("FR:RE")
                 or discovery_info.advertisement.local_name.startswith("FR:GI")
                 or discovery_info.advertisement.local_name.startswith("FR:R2")
+                or discovery_info.advertisement.local_name.startswith("FR:HA")
+
             ):
                 continue
 

--- a/custom_components/rd200_ble/manifest.json
+++ b/custom_components/rd200_ble/manifest.json
@@ -20,5 +20,8 @@
 	{
       "local_name": "FR:R2*"
     }
+	{
+      "local_name": "FR:HA*"
+    }
   ]
 }


### PR DESCRIPTION
my RD200 purchased 2022-01-30 in the US has serial/name starting with FR:HA. 

It appears to be working fine, although I don't have any long term data yet as I just got it. 