### PR TITLE
Fix malformed JSON in manifest.json

### DIFF
--- a/custom_components/rd200_ble/manifest.json
+++ b/custom_components/rd200_ble/manifest.json
@@ -19,7 +19,7 @@
     },
 	{
       "local_name": "FR:R2*"
-    }
+    },
 	{
       "local_name": "FR:HA*"
     }


### PR DESCRIPTION
The latest manifest.json file is missing a comma, which makes
it fail while trying to install through HACS.

So this just adds that comma.