### PR TITLE
Adding a new SN prefix for V2 device

### DIFF
--- a/custom_components/rd200_ble/config_flow.py
+++ b/custom_components/rd200_ble/config_flow.py
@@ -156,6 +156,7 @@ class RD200ConfigFlow(ConfigFlow, domain=DOMAIN):
                 or discovery_info.advertisement.local_name.startswith("FR:R2")
                 or discovery_info.advertisement.local_name.startswith("FR:HA")
                 or discovery_info.advertisement.local_name.startswith("FR:RD")
+                or discovery_info.advertisement.local_name.startswith("FR:GL")
             ):
                 continue
 

--- a/custom_components/rd200_ble/manifest.json
+++ b/custom_components/rd200_ble/manifest.json
@@ -19,6 +19,9 @@
     },
 	{
       "local_name": "FR:RD*"
+    },
+	{
+      "local_name": "FR:GL*"
     }
   ],
   "codeowners": ["@jdeath"],	


### PR DESCRIPTION
Just received a V2 device (manufactured in Dec 2022) and it wasn't being recognized. I added the included changes to the config_flow.py and manifest.json files and it was able to pull the data into HomeAssistant via the esphome ble proxy.

Thanks for the great work! Let me know if I need to update anything else.