### PR TITLE
Add serial FR:GJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RadonEye RD200 (Version 2 and now Version 1) Integration for Homeasssistant. Thr
 
 Based on: https://github.com/EtoTen/radonreader/ and the AirThings BLE Homeassistant Integration (https://github.com/home-assistant/core/tree/dev/homeassistant/components/airthings_ble) and https://github.com/vincegio/airthings-ble, and the ESPHome Native Integration (https://esphome.io/components/sensor/radon_eye_ble.html)
 
-Works for RD200 Version 2 units with serial numbers starting with either FR:RU (United States) , FR:RE (Spain) , FR:GI, FR:HA, FR:HC, FR:GL (??? all sold in the US), and FR:RD. Now works for version 1 (FR:R2 serial numbers). V1 integration currently only supports current radon value, 1 day and 1 month readings. Note the box and the device display do not show the "FR:" portion of the serial number.
+Works for RD200 Version 2 units with serial numbers starting with either FR:RU (United States) , FR:RE (Spain) , FR:GI, FR:HA, FR:HC, FR:GL (??? all sold in the US), FR:RD and FR:GJ. Now works for version 1 (FR:R2 serial numbers). V1 integration currently only supports current radon value, 1 day and 1 month readings. Note the box and the device display do not show the "FR:" portion of the serial number.
 
 If you are pretty sure it is a version 2 device, but has a differnet serial number prefix, edit the manifest.json and line 152 in config_flow.py to include you prefix. If it works, post an issue or a PR and I can add it in.
 

--- a/custom_components/rd200_ble/config_flow.py
+++ b/custom_components/rd200_ble/config_flow.py
@@ -158,6 +158,7 @@ class RD200ConfigFlow(ConfigFlow, domain=DOMAIN):
                 or discovery_info.advertisement.local_name.startswith("FR:HC")
                 or discovery_info.advertisement.local_name.startswith("FR:RD")
                 or discovery_info.advertisement.local_name.startswith("FR:GL")
+                or discovery_info.advertisement.local_name.startswith("FR:GJ")
             ):
                 continue
 

--- a/custom_components/rd200_ble/manifest.json
+++ b/custom_components/rd200_ble/manifest.json
@@ -25,6 +25,9 @@
     },
 	{
       "local_name": "FR:GL*"
+    },
+	{
+      "local_name": "FR:GJ*"
     }
   ],
   "codeowners": ["@jdeath"],	


### PR DESCRIPTION
Got my device in germany with serial prefix FR:GJ, manufactured in november 2022.
The integration works with these changes, I get a connection and valid values.