### PR TITLE
Add support for 'FR:J' serial numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RadonEye RD200 (Version 2 and now Version 1) Integration for Homeasssistant. Thr
 
 Based on: https://github.com/EtoTen/radonreader/ and the AirThings BLE Homeassistant Integration (https://github.com/home-assistant/core/tree/dev/homeassistant/components/airthings_ble) and https://github.com/vincegio/airthings-ble, and the ESPHome Native Integration (https://esphome.io/components/sensor/radon_eye_ble.html)
 
-Works for RD200 Version 2 units with serial numbers starting with either FR:RU (United States) , FR:RE (Spain), FR:GI, FR:H, FR:GL, FR:I (??? all sold in the US), FR:RD and FR:GJ. Now works for version 1 (FR:R2 serial numbers). V1 integration currently only supports current radon value, 1 day and 1 month readings, peak and uptime. Note the box and the device display do not show the "FR:" portion of the serial number.
+Works for RD200 Version 2 units with serial numbers starting with either FR:RU (United States) , FR:RE (Spain), FR:GI, FR:H, FR:GL, FR:I, FR:J (??? all sold in the US), FR:RD and FR:GJ. Now works for version 1 (FR:R2 serial numbers). V1 integration currently only supports current radon value, 1 day and 1 month readings, peak and uptime. Note the box and the device display do not show the "FR:" portion of the serial number.
 
 If you are pretty sure it is a version 2 device, but has a differnet serial number prefix, edit the manifest.json and line 152 in config_flow.py to include you prefix. If it works, post an issue or a PR and I can add it in.
 

--- a/custom_components/rd200_ble/config_flow.py
+++ b/custom_components/rd200_ble/config_flow.py
@@ -159,6 +159,7 @@ class RD200ConfigFlow(ConfigFlow, domain=DOMAIN):
                 or discovery_info.advertisement.local_name.startswith("FR:GL")
                 or discovery_info.advertisement.local_name.startswith("FR:GJ")
                 or discovery_info.advertisement.local_name.startswith("FR:I")
+                or discovery_info.advertisement.local_name.startswith("FR:J")
             ):
                 continue
 

--- a/custom_components/rd200_ble/manifest.json
+++ b/custom_components/rd200_ble/manifest.json
@@ -28,11 +28,18 @@
     },
     {
       "local_name": "FR:I*"
+    },
+    {
+      "local_name": "FR:J*"
     }
   ],
-  "codeowners": ["@jdeath"],
+  "codeowners": [
+    "@jdeath"
+  ],
   "config_flow": true,
-  "dependencies": ["bluetooth_adapters"],
+  "dependencies": [
+    "bluetooth_adapters"
+  ],
   "documentation": "https://www.github.com/jdeath/rd200v2",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jdeath/rd200v2/issues",


### PR DESCRIPTION

**Description**

Add support for 'FR:J' serial numbers.

**Motivation and Context**

I purchased a RadonEye RD200 direct from Ecosense in May of 2025. The unit I received was made in April of 2025 and had a serial number of 'FR:JA'. Without these changes the device could not be discovered.

**Notes**

The firmware version in the app was reported to be v3.0.1.