### PR TITLE
docs: troubleshooting for Ecosense app GATT exclusivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ An issue has been created in homeassistant for the BT performance, but it could 
 
 For VMWare: A user solved "regularly loosing-connection" on their Win10/Nuc running Home-Assistant in a VMWare Virtual machine by updating from VMware Pro 15 to VMWare (free) Verions 16. 
 
+### Device discovered but integration won't set up
+
+If Home Assistant's Bluetooth integration sees your RD200 in scanner diagnostics (correct `FR:*` local name, healthy RSSI from a connectable proxy) but no "Discovered" card ever appears in Settings -> Devices & Services, check whether the **Ecosense mobile app** is actively connected to the device on any phone in Bluetooth range.
+
+The Ecosense app holds an exclusive GATT connection to the RD200 while open. While that connection is alive:
+- The device may still advertise, but HA cannot connect to it to run the config flow.
+- HA's discovery dispatch silently waits for the device to become connectable, leaving no visible error -- the matcher appears not to fire when it's actually blocked on connectability.
+
+Fix: force-close the Ecosense app on every phone in range (not just backgrounded -- Android and iOS can hold BLE connections in the background). Rebooting the phone guarantees release. Within a few minutes, HA's Discovered card should appear.
+
+This can also cause readings to stop updating after setup if the Ecosense app has been used recently; the phone may still be holding the connection.
+
 ### Installation Instructions
 - Add this repo into HACS
 - Install integration


### PR DESCRIPTION
## Motivation

Adds one short troubleshooting section to the README covering a subtle failure mode that currently isn't documented:

**Symptom:** Integration appears installed correctly, HA's Bluetooth scanner cache shows the RD200 with its `FR:*` local name at healthy RSSI from a connectable proxy, the manifest matcher is known to be correct — but no "Discovered" card ever appears under Settings → Devices & Services, and no config flow is ever dispatched.

**Cause:** The Ecosense mobile app is actively connected to the RD200 (on any phone in Bluetooth range) and is holding an exclusive GATT connection. While that connection is alive, HA cannot connect to the device to complete the config flow, so dispatch silently waits indefinitely.

**Fix:** Force-close the Ecosense app on every phone in range (backgrounding is not sufficient; Android and iOS both hold BLE connections in the background). Rebooting the phone guarantees release.

Verified first-hand on HA OS 2026.4.2 with firmware v3.0.1, `jdeath/rd200v2` 4.8, 15-proxy BLE fleet. Matcher (`FR:I*`) matched the device's advertised name (`FR:IJ01RE000293`) correctly; the config flow only fired after the mobile app was killed.

## Change

- Adds a new section `### Device discovered but integration won't set up` between the existing VMWare paragraph and the Installation Instructions. +12 lines to README.md, no code changes.

## Why add to the README rather than a troubleshooting wiki

- The README already contains several inline troubleshooting notes (VMWare, Raspberry Pi BT, HA 2024.1 upgrade, ESPHome BT proxy version) — the style is consistent with this addition.
- This failure mode is upstream of any integration-specific debugging: it affects any BLE integration with an official mobile app, and users reach for this README first.

## Not in scope

- No code changes.
- No changes to serial-number matchers.
- No re-ordering of existing sections.

Happy to tweak wording or placement if you prefer a different location in the file, or to move to a separate TROUBLESHOOTING.md if that's your preference going forward.